### PR TITLE
Notify when automerge must be done manually due to changes to workflow files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,4 +51,4 @@ jobs:
       - name: build the docker image
         shell: bash -l {0}
         run: |
-          docker build -t test .
+          docker build --no-cache -t test .

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # make sure the install below is not cached by docker
 ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
 
+COPY environment.yml /tmp/environment.yml
+
 # Install conda
 RUN echo "**** install dev packages ****" && \
     apk add --no-cache bash ca-certificates wget && \
@@ -35,16 +37,7 @@ RUN echo "**** install dev packages ****" && \
     conda config --show-sources  && \
     conda config --set always_yes yes && \
     mamba update --all && \
-    mamba install --quiet \
-        git \
-        python=3.8 \
-        pip \
-        tini \
-        pygithub \
-        tenacity \
-        requests \
-        ruamel.yaml && \
-    \
+    mamba env update --quiet -f /tmp/environment.yml \
     echo "**** cleanup ****" && \
     rm -rf /var/cache/apk/* && \
     rm -f miniconda.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,38 @@
-FROM mambaorg/micromamba:git-0f27156
+FROM mambaorg/micromamba:git-0f27156 AS build-env
+
+ENV PYTHONDONTWRITEBYTECODE=1
+USER root
+
+COPY environment.yml /tmp/environment.yml
+
+RUN echo "**** install base env ****" && \
+    micromamba install --yes --quiet --name base --file /tmp/environment.yml
+RUN echo "**** cleanup ****" && \
+    micromamba clean --all --force-pkgs-dirs --yes && \
+    find "${MAMBA_ROOT_PREFIX}" -follow -type f \( -iname '*.a' -o -iname '*.pyc' -o -iname '*.js.map' \) -delete
+RUN echo "**** finalize ****" && \
+    mkdir -p "${MAMBA_ROOT_PREFIX}/locks" && \
+    chmod 777 "${MAMBA_ROOT_PREFIX}/locks"
+
+FROM frolvlad/alpine-glibc:alpine-3.16_glibc-2.34
+
+COPY --from=build-env /opt/conda /opt/conda
 
 COPY BASE_IMAGE_LICENSE /
 
 LABEL maintainer="conda-forge core (@conda-forge/core)"
 
 ENV LANG en_US.UTF-8
+
+ARG CONDA_DIR="/opt/conda"
+
+ENV PATH="$CONDA_DIR/bin:$PATH"
 ENV PYTHONDONTWRITEBYTECODE=1
-WORKDIR /
-USER root
 
-COPY environment.yml /tmp/environment.yml
-
-RUN echo "**** install base env ****" && \
-    micromamba install --yes --quiet --name base --file /tmp/environment.yml && \
-    echo "**** cleanup ****" && \
-    micromamba clean --all --force-pkgs-dirs --yes && \
-    find "${MAMBA_ROOT_PREFIX}" -follow -type f \( -iname '*.a' -o -iname '*.pyc' -o -iname '*.js.map' \) -delete && \
-    \
-    echo "**** finalize ****" && \
-    mkdir -p "${MAMBA_ROOT_PREFIX}/locks" && \
-    chmod 777 "${MAMBA_ROOT_PREFIX}/locks"
-
-COPY entrypoint /opt/docker/bin/entrypoint
 RUN mkdir -p cf-autotick-bot-action
 COPY / cf-autotick-bot-action/
-ARG MAMBA_DOCKERFILE_ACTIVATE=1
 RUN cd cf-autotick-bot-action && \
     pip install -e .
 
-ENTRYPOINT ["{MAMBA_ROOT_PREFIX}/bin/tini", "--", "/opt/docker/bin/entrypoint"]
-CMD ["/bin/bash"]
+COPY entrypoint /opt/docker/bin/entrypoint
+ENTRYPOINT ["/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN echo "**** install dev packages ****" && \
     conda config --show-sources  && \
     conda config --set always_yes yes && \
     mamba update --all && \
-    mamba env update --quiet -f /tmp/environment.yml \
+    mamba env update --quiet -f /tmp/environment.yml && \
     echo "**** cleanup ****" && \
     rm -rf /var/cache/apk/* && \
     rm -f miniconda.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,60 +1,32 @@
-FROM frolvlad/alpine-glibc:alpine-3.10
+FROM mambaorg/micromamba:git-0f27156
 
-# much of image code ripped from
-# https://github.com/Docker-Hub-frolvlad/docker-alpine-miniconda3
 COPY BASE_IMAGE_LICENSE /
 
 LABEL maintainer="conda-forge core (@conda-forge/core)"
 
 ENV LANG en_US.UTF-8
-
-ARG CONDA_DIR="/opt/conda"
-
-ENV PATH="$CONDA_DIR/bin:$PATH"
 ENV PYTHONDONTWRITEBYTECODE=1
-
-# make sure the install below is not cached by docker
-ADD http://worldclockapi.com/api/json/utc/now /opt/docker/etc/timestamp
+WORKDIR /
+USER root
 
 COPY environment.yml /tmp/environment.yml
 
-# Install conda
-RUN echo "**** install dev packages ****" && \
-    apk add --no-cache bash ca-certificates wget && \
-    \
-    echo "**** get Mambaforge ****" && \
-    mkdir -p "$CONDA_DIR" && \
-    wget "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh" -O miniconda.sh && \
-    \
-    echo "**** install Mambaforge ****" && \
-    bash miniconda.sh -f -b -p "$CONDA_DIR" && \
-    \
-    echo "**** install base env ****" && \
-    source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate base && \
-    conda config --set show_channel_urls True  && \
-    conda config --add channels conda-forge  && \
-    conda config --show-sources  && \
-    conda config --set always_yes yes && \
-    mamba update --all && \
-    mamba env update --quiet -f /tmp/environment.yml && \
+RUN echo "**** install base env ****" && \
+    micromamba install --yes --quiet --name base --file /tmp/environment.yml && \
     echo "**** cleanup ****" && \
-    rm -rf /var/cache/apk/* && \
-    rm -f miniconda.sh && \
-    conda clean --all --force-pkgs-dirs --yes && \
-    find "$CONDA_DIR" -follow -type f \( -iname '*.a' -o -iname '*.pyc' -o -iname '*.js.map' \) -delete && \
+    micromamba clean --all --force-pkgs-dirs --yes && \
+    find "${MAMBA_ROOT_PREFIX}" -follow -type f \( -iname '*.a' -o -iname '*.pyc' -o -iname '*.js.map' \) -delete && \
     \
     echo "**** finalize ****" && \
-    mkdir -p "$CONDA_DIR/locks" && \
-    chmod 777 "$CONDA_DIR/locks"
+    mkdir -p "${MAMBA_ROOT_PREFIX}/locks" && \
+    chmod 777 "${MAMBA_ROOT_PREFIX}/locks"
 
 COPY entrypoint /opt/docker/bin/entrypoint
 RUN mkdir -p cf-autotick-bot-action
 COPY / cf-autotick-bot-action/
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
 RUN cd cf-autotick-bot-action && \
-    source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate base && \
     pip install -e .
 
-ENTRYPOINT ["/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint"]
+ENTRYPOINT ["{MAMBA_ROOT_PREFIX}/bin/tini", "--", "/opt/docker/bin/entrypoint"]
 CMD ["/bin/bash"]

--- a/conda_forge_automerge_action/__main__.py
+++ b/conda_forge_automerge_action/__main__.py
@@ -28,6 +28,8 @@ def main():
             sha = event_data['sha']
         elif event_name == 'check_suite':
             sha = event_data['check_suite']['head_sha']
+        else:
+            raise NotImplementedError(f"Should never happen. {event_name=}")
 
         repo = gh.get_repo(os.environ['GITHUB_REPOSITORY'])
         for pr in repo.get_pulls():

--- a/conda_forge_automerge_action/api_sessions.py
+++ b/conda_forge_automerge_action/api_sessions.py
@@ -31,7 +31,7 @@ def get_actor_token():
         return "x-access-token", os.environ["INPUT_GITHUB_TOKEN"], False
 
 
-def create_api_sessions(github_token):
+def create_api_sessions(github_token: str) -> Github:
     """Create API sessions for GitHub.
 
     Parameters

--- a/conda_forge_automerge_action/automerge.py
+++ b/conda_forge_automerge_action/automerge.py
@@ -320,7 +320,7 @@ def _no_extra_pr_commits(pr):
     return all(e.event != "committed" for e in events[label_ind+1:])
 
 
-def _check_pr(pr, cfg):
+def _check_pr(pr: PullRequest, cfg):
     """make sure a PR is ok to automerge"""
     if any(label.name == "automerge" for label in pr.get_labels()):
         _no_commits = _no_extra_pr_commits(pr)
@@ -368,6 +368,13 @@ maintainer to do so) if you'd like to enable automerge again!
     # can we automerge in this feedstock?
     if not _automerge_me(cfg):
         return False, "automated bot merges are turned off for this feedstock"
+
+    # Ensure files under .github/workflows have not been modified
+    if any(
+        f.filename.startswith(".github/workflows")
+        for f in pr.get_files()
+    ):
+        return False, "Workflow files have been modified. Please merge manually."
 
     return True, None
 

--- a/conda_forge_automerge_action/automerge.py
+++ b/conda_forge_automerge_action/automerge.py
@@ -465,7 +465,9 @@ def _automerge_pr(repo: Repository, pr: PullRequest) -> Tuple[bool, str]:
     except Exception:
         LOGGER.exception("API error in POST to merge")
         merge_status_merged = False
-        merge_status_message = "API error in POST to merge"
+        merge_status_message = (
+            "API error in POST to merge. Check Actions logs for stack trace."
+        )
 
     if not merge_status_merged:
         _comment_on_pr(

--- a/conda_forge_automerge_action/automerge.py
+++ b/conda_forge_automerge_action/automerge.py
@@ -463,6 +463,7 @@ def _automerge_pr(repo: Repository, pr: PullRequest) -> Tuple[bool, str]:
         else:
             merge_status_message = None
     except Exception:
+        LOGGER.exception("API error in POST to merge")
         merge_status_merged = False
         merge_status_message = "API error in POST to merge"
 

--- a/conda_forge_automerge_action/automerge.py
+++ b/conda_forge_automerge_action/automerge.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import logging
 import datetime
@@ -8,6 +10,12 @@ import time
 import random
 
 from ruamel.yaml import YAML
+
+from typing import TYPE_CHECKING, Tuple
+
+if TYPE_CHECKING:
+    from github.Repository import Repository
+    from github.PullRequest import PullRequest
 
 LOGGER = logging.getLogger(__name__)
 
@@ -399,7 +407,7 @@ I considered the following status checks when analyzing this PR:
     _comment_on_pr_with_race(pr, comment, check_slug)
 
 
-def _automerge_pr(repo, pr):
+def _automerge_pr(repo: Repository, pr: PullRequest) -> Tuple[bool, str]:
     cfg = _get_conda_forge_config(pr)
     allowed, msg = _check_pr(pr, cfg)
 
@@ -474,7 +482,7 @@ def _automerge_pr(repo, pr):
         return True, "all is well :)"
 
 
-def automerge_pr(repo, pr):
+def automerge_pr(repo: Repository, pr: PullRequest) -> Tuple[bool, str]:
     """Possibly automerge a PR.
 
     Parameters

--- a/conda_forge_automerge_action/tests/test_optout.py
+++ b/conda_forge_automerge_action/tests/test_optout.py
@@ -1,6 +1,6 @@
 import pytest
 
-from..automerge import _automerge_me
+from ..automerge import _automerge_me
 
 
 @pytest.mark.parametrize('cfg_bool', [

--- a/entrypoint
+++ b/entrypoint
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 echo " "
 echo "==================================================================================================="
@@ -6,15 +6,5 @@ echo "==========================================================================
 
 git config --global user.name "conda-forge-webservices[bot]"
 git config --global user.email "91080706+conda-forge-webservices[bot]@users.noreply.github.com"
-
-source /opt/conda/etc/profile.d/conda.sh
-
-conda activate base
-
-conda info
-
-echo " "
-echo "==================================================================================================="
-echo "==================================================================================================="
 
 run-automerge-action

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+name: base
+channels:
+- conda-forge
+dependencies:
+- git
+- python=3.8
+- pip
+- tini
+- pygithub
+- tenacity
+- requests
+- ruamel.yaml

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 dependencies:
 - git
-- python=3.8
+- python=3.11
 - pip
 - tini
 - pygithub

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,17 +8,21 @@
 
 4. Clone the upstream repo (`https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock`) to `cf-test-master`:
 
+  ```bash
   git clone https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock.git cf-test-master
+  ```
 
 5. Add the upstream remote
 
-   ```
+   ```bash
    cd cf-autotick-bot-test-package-feedstock
    git remote add upstream https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock.git
    cd ..
    ```
 
-6. Run the script `run_tests.sh` feeding it the version number of the test as `vXYZ`
+6. Ensure that `conda-smithy` is installed in your active Conda environment.
+
+7. Run the script `run_tests.sh` feeding it the version number of the test as `vXYZ`
    (e.g., `./run_tests.sh v8`).
 
-7. The script will make a series of PRs. Some should merge and some should not.
+8. The script will make a series of PRs. Some should merge and some should not.

--- a/scripts/make_ci_fail.py
+++ b/scripts/make_ci_fail.py
@@ -3,9 +3,11 @@ import os
 import sys
 import github
 import subprocess
-import yaml
+from ruamel.yaml import YAML
 import uuid
 
+
+yaml = YAML()
 
 META = """\
 {% set name = "cf-autotick-bot-test-package" %}
@@ -119,7 +121,7 @@ with open("recipe/meta.yaml", "w") as fp:
     fp.write(META)
 
 with open("conda-forge.yml", "r") as fp:
-    cfg = yaml.safe_load(fp)
+    cfg = yaml.load(fp)
 
 cfg["provider"]["linux"] = sys.argv[1]
 cfg["provider"]["osx"] = sys.argv[2]

--- a/scripts/make_ci_fail.py
+++ b/scripts/make_ci_fail.py
@@ -66,21 +66,19 @@ print("\n\n=========================================")
 print("making the base branch")
 try:
     subprocess.run(
-        "pushd ../cf-test-master && "
-        "git checkout main && "
-        "git reset --hard HEAD && "
-        "git checkout -b %s && "
-        "git push --set-upstream origin %s && "
-        "popd" % (BASE_BRANCH, BASE_BRANCH),
+        f"cd ../cf-test-master && "
+        f"git checkout main && "
+        f"git reset --hard HEAD && "
+        f"git checkout -b {BASE_BRANCH} && "
+        f"git push --set-upstream origin {BASE_BRANCH}",
         shell=True,
         check=True,
     )
 except Exception:
     subprocess.run(
-        "pushd ../cf-test-master && "
-        "git checkout %s && "
-        "git push --set-upstream origin %s && "
-        "popd" % (BASE_BRANCH, BASE_BRANCH),
+        f"cd ../cf-test-master && "
+        f"git checkout {BASE_BRANCH} && "
+        f"git push --set-upstream origin {BASE_BRANCH}",
         shell=True,
     )
 

--- a/scripts/make_ci_fail.py
+++ b/scripts/make_ci_fail.py
@@ -67,7 +67,7 @@ print("making the base branch")
 try:
     subprocess.run(
         "pushd ../cf-test-master && "
-        "git checkout master && "
+        "git checkout main && "
         "git reset --hard HEAD && "
         "git checkout -b %s && "
         "git push --set-upstream origin %s && "

--- a/scripts/make_extra_commit.py
+++ b/scripts/make_extra_commit.py
@@ -65,21 +65,19 @@ print("\n\n=========================================")
 print("making the base branch")
 try:
     subprocess.run(
-        "pushd ../cf-test-master && "
-        "git checkout main && "
-        "git reset --hard HEAD && "
-        "git checkout -b %s && "
-        "git push --set-upstream origin %s && "
-        "popd" % (BASE_BRANCH, BASE_BRANCH),
+        f"cd ../cf-test-master && "
+        f"git checkout main && "
+        f"git reset --hard HEAD && "
+        f"git checkout -b {BASE_BRANCH} && "
+        f"git push --set-upstream origin {BASE_BRANCH}",
         shell=True,
         check=True,
     )
 except Exception:
     subprocess.run(
-        "pushd ../cf-test-master && "
-        "git checkout %s && "
-        "git push --set-upstream origin %s && "
-        "popd" % (BASE_BRANCH, BASE_BRANCH),
+        f"cd ../cf-test-master && "
+        f"git checkout {BASE_BRANCH} && "
+        f"git push --set-upstream origin {BASE_BRANCH}",
         shell=True,
     )
 

--- a/scripts/make_extra_commit.py
+++ b/scripts/make_extra_commit.py
@@ -66,7 +66,7 @@ print("making the base branch")
 try:
     subprocess.run(
         "pushd ../cf-test-master && "
-        "git checkout master && "
+        "git checkout main && "
         "git reset --hard HEAD && "
         "git checkout -b %s && "
         "git push --set-upstream origin %s && "

--- a/scripts/make_extra_commit.py
+++ b/scripts/make_extra_commit.py
@@ -3,9 +3,11 @@ import os
 import sys
 import github
 import subprocess
-import yaml
+from ruamel.yaml import YAML
 import uuid
 
+
+yaml = YAML()
 
 META = """\
 {% set name = "cf-autotick-bot-test-package" %}
@@ -117,7 +119,7 @@ with open("recipe/meta.yaml", "w") as fp:
     fp.write(META)
 
 with open("conda-forge.yml", "r") as fp:
-    cfg = yaml.safe_load(fp)
+    cfg = yaml.load(fp)
 
 cfg["provider"]["linux"] = sys.argv[1]
 cfg["provider"]["osx"] = sys.argv[2]

--- a/scripts/make_no_merge_user.py
+++ b/scripts/make_no_merge_user.py
@@ -3,8 +3,11 @@ import os
 import sys
 import github
 import subprocess
-import yaml
+from ruamel.yaml import YAML
 import uuid
+
+
+yaml = YAML()
 
 META = """\
 {% set name = "cf-autotick-bot-test-package" %}
@@ -116,7 +119,7 @@ with open("recipe/meta.yaml", "w") as fp:
     fp.write(META)
 
 with open("conda-forge.yml", "r") as fp:
-    cfg = yaml.safe_load(fp)
+    cfg = yaml.load(fp)
 
 cfg["provider"]["linux"] = sys.argv[1]
 cfg["provider"]["osx"] = sys.argv[2]

--- a/scripts/make_no_merge_user.py
+++ b/scripts/make_no_merge_user.py
@@ -65,7 +65,7 @@ print("making the base branch")
 try:
     subprocess.run(
         "pushd ../cf-test-master && "
-        "git checkout master && "
+        "git checkout main && "
         "git reset --hard HEAD && "
         "git checkout -b %s && "
         "git push --set-upstream origin %s && "

--- a/scripts/make_no_merge_user.py
+++ b/scripts/make_no_merge_user.py
@@ -64,21 +64,19 @@ print("\n\n=========================================")
 print("making the base branch")
 try:
     subprocess.run(
-        "pushd ../cf-test-master && "
-        "git checkout main && "
-        "git reset --hard HEAD && "
-        "git checkout -b %s && "
-        "git push --set-upstream origin %s && "
-        "popd" % (BASE_BRANCH, BASE_BRANCH),
+        f"cd ../cf-test-master && "
+        f"git checkout main && "
+        f"git reset --hard HEAD && "
+        f"git checkout -b {BASE_BRANCH} && "
+        f"git push --set-upstream origin {BASE_BRANCH}",
         shell=True,
         check=True,
     )
 except Exception:
     subprocess.run(
-        "pushd ../cf-test-master && "
-        "git checkout %s && "
-        "git push --set-upstream origin %s && "
-        "popd" % (BASE_BRANCH, BASE_BRANCH),
+        f"cd ../cf-test-master && "
+        f"git checkout {BASE_BRANCH} && "
+        f"git push --set-upstream origin {BASE_BRANCH}",
         shell=True,
     )
 

--- a/scripts/make_prs.py
+++ b/scripts/make_prs.py
@@ -3,8 +3,11 @@ import os
 import sys
 import github
 import subprocess
-import yaml
+from ruamel.yaml import YAML
 import uuid
+
+
+yaml = YAML()
 
 META = """\
 {% set name = "cf-autotick-bot-test-package" %}
@@ -116,7 +119,7 @@ with open("recipe/meta.yaml", "w") as fp:
     fp.write(META)
 
 with open("conda-forge.yml", "r") as fp:
-    cfg = yaml.safe_load(fp)
+    cfg = yaml.load(fp)
 
 cfg["provider"]["linux"] = sys.argv[1]
 cfg["provider"]["osx"] = sys.argv[2]

--- a/scripts/make_prs.py
+++ b/scripts/make_prs.py
@@ -65,7 +65,7 @@ print("making the base branch")
 try:
     subprocess.run(
         "pushd ../cf-test-master && "
-        "git checkout master && "
+        "git checkout main && "
         "git reset --hard HEAD && "
         "git checkout -b %s && "
         "git push --set-upstream origin %s && "

--- a/scripts/make_prs.py
+++ b/scripts/make_prs.py
@@ -64,21 +64,19 @@ print("\n\n=========================================")
 print("making the base branch")
 try:
     subprocess.run(
-        "pushd ../cf-test-master && "
-        "git checkout main && "
-        "git reset --hard HEAD && "
-        "git checkout -b %s && "
-        "git push --set-upstream origin %s && "
-        "popd" % (BASE_BRANCH, BASE_BRANCH),
+        f"cd ../cf-test-master && "
+        f"git checkout main && "
+        f"git reset --hard HEAD && "
+        f"git checkout -b {BASE_BRANCH} && "
+        f"git push --set-upstream origin {BASE_BRANCH}",
         shell=True,
         check=True,
     )
 except Exception:
     subprocess.run(
-        "pushd ../cf-test-master && "
-        "git checkout %s && "
-        "git push --set-upstream origin %s && "
-        "popd" % (BASE_BRANCH, BASE_BRANCH),
+        f"cd ../cf-test-master && "
+        f"git checkout {BASE_BRANCH} && "
+        f"git push --set-upstream origin {BASE_BRANCH}",
         shell=True,
     )
 

--- a/scripts/move_to_dev_branch.py
+++ b/scripts/move_to_dev_branch.py
@@ -30,7 +30,7 @@ subprocess.run(
     "git checkout main && "
     "git pull && "
     "git add .github/workflows/automerge.yml && "
-    "git ci --allow-empty -m '[ci skip] automerge to dev' && "
+    "git commit --allow-empty -m '[ci skip] automerge to dev' && "
     "git push",
     shell=True,
     check=True,

--- a/scripts/move_to_dev_branch.py
+++ b/scripts/move_to_dev_branch.py
@@ -27,7 +27,7 @@ jobs:
 
 subprocess.run(
     "pushd ../cf-test-master && "
-    "git checkout master && "
+    "git checkout main && "
     "git pull && "
     "git add .github/workflows/automerge.yml && "
     "git ci --allow-empty -m '[ci skip] automerge to dev' && "

--- a/scripts/move_to_dev_branch.py
+++ b/scripts/move_to_dev_branch.py
@@ -26,13 +26,12 @@ jobs:
 """)
 
 subprocess.run(
-    "pushd ../cf-test-master && "
+    "cd ../cf-test-master && "
     "git checkout main && "
     "git pull && "
     "git add .github/workflows/automerge.yml && "
     "git ci --allow-empty -m '[ci skip] automerge to dev' && "
-    "git push && "
-    "popd",
+    "git push",
     shell=True,
     check=True,
 )

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -7,8 +7,8 @@ export CONDA_SMITHY_LOGLEVEL=DEBUG
 pushd cf-autotick-bot-test-package-feedstock
 
 git reset --hard HEAD
-git checkout master
-git pull upstream master
+git checkout main
+git pull upstream main
 git pull
 git push
 


### PR DESCRIPTION
The core of this PR is [240f92e](https://github.com/conda-forge/automerge-action/pull/9/commits/240f92e1e62e42208e9b7abdfe108b210b0ac6c2): if any file under `.github/workflows` has been modified, then fail with the PR comment `Workflow files have been modified. Please merge manually.`

I need to test it. I tried to follow the instructions under `scripts/` and failed, see #10. 

I don't believe that I have access to the Dockerhub registry, so I don't think I can push to the `dev` tag.

What should I do? Any advice @chrisburr?

checklist:

- [ ] tested the changes live by using the `dev` version of the action


Here are some feedstocks where this could be live-tested:
https://github.com/conda-forge/boto3-stubs-lite-feedstock/pull/73#issuecomment-1300458884
https://github.com/conda-forge/mypy-boto3-s3-feedstock/pull/160#issuecomment-1299944027
https://github.com/conda-forge/mypy_boto3_rds-feedstock/pull/168#issuecomment-1299682937
https://github.com/conda-forge/mypy_boto3_ec2-feedstock/pull/208#issuecomment-1299577234
