### PR TITLE
Rework dockerfile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,4 +51,4 @@ jobs:
       - name: build the docker image
         shell: bash -l {0}
         run: |
-          docker build -t test .
+          docker build --no-cache -t test .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,60 +1,35 @@
-FROM frolvlad/alpine-glibc:alpine-3.10
+FROM mambaorg/micromamba:git-0f27156
 
-# much of image code ripped from
-# https://github.com/Docker-Hub-frolvlad/docker-alpine-miniconda3
 COPY BASE_IMAGE_LICENSE /
 
 LABEL maintainer="conda-forge core (@conda-forge/core)"
 
 ENV LANG en_US.UTF-8
-
-ARG CONDA_DIR="/opt/conda"
-
-ENV PATH="$CONDA_DIR/bin:$PATH"
 ENV PYTHONDONTWRITEBYTECODE=1
+WORKDIR /
+USER root
 
 # make sure the install below is not cached by docker
 ADD https://loripsum.net/api /opt/docker/etc/gibberish-to-bust-docker-image-cache
 
 COPY environment.yml /tmp/environment.yml
 
-# Install conda
-RUN echo "**** install dev packages ****" && \
-    apk add --no-cache bash ca-certificates wget && \
-    \
-    echo "**** get Mambaforge ****" && \
-    mkdir -p "$CONDA_DIR" && \
-    wget "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh" -O miniconda.sh && \
-    \
-    echo "**** install Mambaforge ****" && \
-    bash miniconda.sh -f -b -p "$CONDA_DIR" && \
-    \
-    echo "**** install base env ****" && \
-    source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate base && \
-    conda config --set show_channel_urls True  && \
-    conda config --add channels conda-forge  && \
-    conda config --show-sources  && \
-    conda config --set always_yes yes && \
-    mamba update --all && \
-    mamba env update --quiet -f /tmp/environment.yml && \
+RUN echo "**** install base env ****" && \
+    micromamba install --yes --quiet --name base --file /tmp/environment.yml && \
     echo "**** cleanup ****" && \
-    rm -rf /var/cache/apk/* && \
-    rm -f miniconda.sh && \
-    conda clean --all --force-pkgs-dirs --yes && \
-    find "$CONDA_DIR" -follow -type f \( -iname '*.a' -o -iname '*.pyc' -o -iname '*.js.map' \) -delete && \
+    micromamba clean --all --force-pkgs-dirs --yes && \
+    find "${MAMBA_ROOT_PREFIX}" -follow -type f \( -iname '*.a' -o -iname '*.pyc' -o -iname '*.js.map' \) -delete && \
     \
     echo "**** finalize ****" && \
-    mkdir -p "$CONDA_DIR/locks" && \
-    chmod 777 "$CONDA_DIR/locks"
+    mkdir -p "${MAMBA_ROOT_PREFIX}/locks" && \
+    chmod 777 "${MAMBA_ROOT_PREFIX}/locks"
 
 COPY entrypoint /opt/docker/bin/entrypoint
 RUN mkdir -p cf-autotick-bot-action
 COPY / cf-autotick-bot-action/
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
 RUN cd cf-autotick-bot-action && \
-    source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate base && \
     pip install -e .
 
-ENTRYPOINT ["/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint"]
+ENTRYPOINT ["{MAMBA_ROOT_PREFIX}/bin/tini", "--", "/opt/docker/bin/entrypoint"]
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # make sure the install below is not cached by docker
 ADD https://loripsum.net/api /opt/docker/etc/gibberish-to-bust-docker-image-cache
 
+COPY environment.yml /tmp/environment.yml
+
 # Install conda
 RUN echo "**** install dev packages ****" && \
     apk add --no-cache bash ca-certificates wget && \
@@ -35,16 +37,7 @@ RUN echo "**** install dev packages ****" && \
     conda config --show-sources  && \
     conda config --set always_yes yes && \
     mamba update --all && \
-    mamba install --quiet \
-        git \
-        python=3.8 \
-        pip \
-        tini \
-        pygithub \
-        tenacity \
-        requests \
-        ruamel.yaml && \
-    \
+    mamba env update --quiet -f /tmp/environment.yml && \
     echo "**** cleanup ****" && \
     rm -rf /var/cache/apk/* && \
     rm -f miniconda.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
-FROM mambaorg/micromamba:git-0f27156
+FROM mambaorg/micromamba:git-0f27156 AS build-env
 
-COPY BASE_IMAGE_LICENSE /
-
-LABEL maintainer="conda-forge core (@conda-forge/core)"
-
-ENV LANG en_US.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1
-WORKDIR /
 USER root
 
 # make sure the install below is not cached by docker
@@ -15,21 +9,33 @@ ADD https://loripsum.net/api /opt/docker/etc/gibberish-to-bust-docker-image-cach
 COPY environment.yml /tmp/environment.yml
 
 RUN echo "**** install base env ****" && \
-    micromamba install --yes --quiet --name base --file /tmp/environment.yml && \
-    echo "**** cleanup ****" && \
+    micromamba install --yes --quiet --name base --file /tmp/environment.yml
+RUN echo "**** cleanup ****" && \
     micromamba clean --all --force-pkgs-dirs --yes && \
-    find "${MAMBA_ROOT_PREFIX}" -follow -type f \( -iname '*.a' -o -iname '*.pyc' -o -iname '*.js.map' \) -delete && \
-    \
-    echo "**** finalize ****" && \
+    find "${MAMBA_ROOT_PREFIX}" -follow -type f \( -iname '*.a' -o -iname '*.pyc' -o -iname '*.js.map' \) -delete
+RUN echo "**** finalize ****" && \
     mkdir -p "${MAMBA_ROOT_PREFIX}/locks" && \
     chmod 777 "${MAMBA_ROOT_PREFIX}/locks"
 
-COPY entrypoint /opt/docker/bin/entrypoint
+FROM frolvlad/alpine-glibc:alpine-3.16_glibc-2.34
+
+COPY --from=build-env /opt/conda /opt/conda
+
+COPY BASE_IMAGE_LICENSE /
+
+LABEL maintainer="conda-forge core (@conda-forge/core)"
+
+ENV LANG en_US.UTF-8
+
+ARG CONDA_DIR="/opt/conda"
+
+ENV PATH="$CONDA_DIR/bin:$PATH"
+ENV PYTHONDONTWRITEBYTECODE=1
+
 RUN mkdir -p cf-autotick-bot-action
 COPY / cf-autotick-bot-action/
-ARG MAMBA_DOCKERFILE_ACTIVATE=1
 RUN cd cf-autotick-bot-action && \
     pip install -e .
 
-ENTRYPOINT ["{MAMBA_ROOT_PREFIX}/bin/tini", "--", "/opt/docker/bin/entrypoint"]
-CMD ["/bin/bash"]
+COPY entrypoint /opt/docker/bin/entrypoint
+ENTRYPOINT ["/opt/conda/bin/tini", "--", "/opt/docker/bin/entrypoint"]

--- a/entrypoint
+++ b/entrypoint
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 echo " "
 echo "==================================================================================================="
@@ -6,15 +6,5 @@ echo "==========================================================================
 
 git config --global user.name "conda-forge-webservices[bot]"
 git config --global user.email "91080706+conda-forge-webservices[bot]@users.noreply.github.com"
-
-source /opt/conda/etc/profile.d/conda.sh
-
-conda activate base
-
-conda info
-
-echo " "
-echo "==================================================================================================="
-echo "==================================================================================================="
 
 run-automerge-action

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+name: base
+channels:
+- conda-forge
+dependencies:
+- git
+- python=3.8
+- pip
+- tini
+- pygithub
+- tenacity
+- requests
+- ruamel.yaml

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 dependencies:
 - git
-- python=3.8
+- python=3.11
 - pip
 - tini
 - pygithub


### PR DESCRIPTION
- Break out requirements into a separate `environment.yml` (useful for local installation)
- Bump Python to 3.11
- Generate Conda environment in a separate stage (saves ~11% space without conda/micromamba)
  - required switching shell to `sh` since `bash` isn't in the latest alpine image (I had to replace real activation by adding `/opt/conda/bin` to `PATH`)

checklist:

- [ ] tested the changes live by using the `dev` version of the action
