### PR TITLE
Check for modified workflow files

### DIFF
--- a/conda_forge_automerge_action/automerge.py
+++ b/conda_forge_automerge_action/automerge.py
@@ -369,6 +369,13 @@ maintainer to do so) if you'd like to enable automerge again!
     if not _automerge_me(cfg):
         return False, "automated bot merges are turned off for this feedstock"
 
+    # Ensure files under .github/workflows have not been modified
+    if any(
+        f.filename.startswith(".github/workflows")
+        for f in pr.get_files()
+    ):
+        return False, "Workflow files have been modified. Please merge manually."
+
     return True, None
 
 

--- a/conda_forge_automerge_action/automerge.py
+++ b/conda_forge_automerge_action/automerge.py
@@ -374,7 +374,7 @@ maintainer to do so) if you'd like to enable automerge again!
         f.filename.startswith(".github/workflows")
         for f in pr.get_files()
     ):
-        return False, "Workflow files have been modified. Please merge manually."
+        return False, "GitHub Actions workflow files have been modified, and thus automerge cannot proceed due to API permission limitations. Please merge manually."
 
     return True, None
 


### PR DESCRIPTION
Fixes the problem where automerge fails with a non-specific API error whenever workflow files are modified. (Thanks @chrisburr for explaining the reason.)

NEEDS TESTING

checklist:

- [ ] tested the changes live by using the `dev` version of the action
