### PR TITLE
Fix scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,24 +1,30 @@
 # How to use this code
 
+*REQUIRED*: You must have write access to `conda-forge/cf-autotick-bot-test-package-feedstock`.
+
 1. Change directory to this directory (i.e. `cd scripts`).
 
-2. Fork this feedstock `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock`
+2. Fork the feedstock `https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock`
 
 3. Clone your fork `https://github.com/<username>/cf-autotick-bot-test-package-feedstock.git`
 
 4. Clone the upstream repo (`https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock`) to `cf-test-master`:
 
+  ```bash
   git clone https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock.git cf-test-master
+  ```
 
 5. Add the upstream remote
 
-   ```
+   ```bash
    cd cf-autotick-bot-test-package-feedstock
    git remote add upstream https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock.git
    cd ..
    ```
 
-6. Run the script `run_tests.sh` feeding it the version number of the test as `vXYZ`
+6. Ensure that `conda-smithy` is installed in your active Conda environment.
+
+7. Run the script `run_tests.sh` feeding it the version number of the test as `vXYZ`
    (e.g., `./run_tests.sh v8`).
 
-7. The script will make a series of PRs. Some should merge and some should not.
+8. The script will make a series of PRs. Some should merge and some should not.

--- a/scripts/make_ci_fail.py
+++ b/scripts/make_ci_fail.py
@@ -3,9 +3,11 @@ import os
 import sys
 import github
 import subprocess
-import yaml
+from ruamel.yaml import YAML
 import uuid
 
+
+yaml = YAML()
 
 META = """\
 {% set name = "cf-autotick-bot-test-package" %}
@@ -119,7 +121,7 @@ with open("recipe/meta.yaml", "w") as fp:
     fp.write(META)
 
 with open("conda-forge.yml", "r") as fp:
-    cfg = yaml.safe_load(fp)
+    cfg = yaml.load(fp)
 
 cfg["provider"]["linux"] = sys.argv[1]
 cfg["provider"]["osx"] = sys.argv[2]

--- a/scripts/make_ci_fail.py
+++ b/scripts/make_ci_fail.py
@@ -66,21 +66,19 @@ print("\n\n=========================================")
 print("making the base branch")
 try:
     subprocess.run(
-        "pushd ../cf-test-master && "
-        "git checkout main && "
-        "git reset --hard HEAD && "
-        "git checkout -b %s && "
-        "git push --set-upstream origin %s && "
-        "popd" % (BASE_BRANCH, BASE_BRANCH),
+        f"cd ../cf-test-master && "
+        f"git checkout main && "
+        f"git reset --hard HEAD && "
+        f"git checkout -b {BASE_BRANCH} && "
+        f"git push --set-upstream origin {BASE_BRANCH}",
         shell=True,
         check=True,
     )
 except Exception:
     subprocess.run(
-        "pushd ../cf-test-master && "
-        "git checkout %s && "
-        "git push --set-upstream origin %s && "
-        "popd" % (BASE_BRANCH, BASE_BRANCH),
+        f"cd ../cf-test-master && "
+        f"git checkout {BASE_BRANCH} && "
+        f"git push --set-upstream origin {BASE_BRANCH}",
         shell=True,
     )
 

--- a/scripts/make_ci_fail.py
+++ b/scripts/make_ci_fail.py
@@ -67,7 +67,7 @@ print("making the base branch")
 try:
     subprocess.run(
         "pushd ../cf-test-master && "
-        "git checkout master && "
+        "git checkout main && "
         "git reset --hard HEAD && "
         "git checkout -b %s && "
         "git push --set-upstream origin %s && "

--- a/scripts/make_extra_commit.py
+++ b/scripts/make_extra_commit.py
@@ -65,21 +65,19 @@ print("\n\n=========================================")
 print("making the base branch")
 try:
     subprocess.run(
-        "pushd ../cf-test-master && "
-        "git checkout main && "
-        "git reset --hard HEAD && "
-        "git checkout -b %s && "
-        "git push --set-upstream origin %s && "
-        "popd" % (BASE_BRANCH, BASE_BRANCH),
+        f"cd ../cf-test-master && "
+        f"git checkout main && "
+        f"git reset --hard HEAD && "
+        f"git checkout -b {BASE_BRANCH} && "
+        f"git push --set-upstream origin {BASE_BRANCH}",
         shell=True,
         check=True,
     )
 except Exception:
     subprocess.run(
-        "pushd ../cf-test-master && "
-        "git checkout %s && "
-        "git push --set-upstream origin %s && "
-        "popd" % (BASE_BRANCH, BASE_BRANCH),
+        f"cd ../cf-test-master && "
+        f"git checkout {BASE_BRANCH} && "
+        f"git push --set-upstream origin {BASE_BRANCH}",
         shell=True,
     )
 

--- a/scripts/make_extra_commit.py
+++ b/scripts/make_extra_commit.py
@@ -66,7 +66,7 @@ print("making the base branch")
 try:
     subprocess.run(
         "pushd ../cf-test-master && "
-        "git checkout master && "
+        "git checkout main && "
         "git reset --hard HEAD && "
         "git checkout -b %s && "
         "git push --set-upstream origin %s && "

--- a/scripts/make_extra_commit.py
+++ b/scripts/make_extra_commit.py
@@ -3,9 +3,11 @@ import os
 import sys
 import github
 import subprocess
-import yaml
+from ruamel.yaml import YAML
 import uuid
 
+
+yaml = YAML()
 
 META = """\
 {% set name = "cf-autotick-bot-test-package" %}
@@ -117,7 +119,7 @@ with open("recipe/meta.yaml", "w") as fp:
     fp.write(META)
 
 with open("conda-forge.yml", "r") as fp:
-    cfg = yaml.safe_load(fp)
+    cfg = yaml.load(fp)
 
 cfg["provider"]["linux"] = sys.argv[1]
 cfg["provider"]["osx"] = sys.argv[2]

--- a/scripts/make_no_merge_user.py
+++ b/scripts/make_no_merge_user.py
@@ -3,8 +3,11 @@ import os
 import sys
 import github
 import subprocess
-import yaml
+from ruamel.yaml import YAML
 import uuid
+
+
+yaml = YAML()
 
 META = """\
 {% set name = "cf-autotick-bot-test-package" %}
@@ -116,7 +119,7 @@ with open("recipe/meta.yaml", "w") as fp:
     fp.write(META)
 
 with open("conda-forge.yml", "r") as fp:
-    cfg = yaml.safe_load(fp)
+    cfg = yaml.load(fp)
 
 cfg["provider"]["linux"] = sys.argv[1]
 cfg["provider"]["osx"] = sys.argv[2]

--- a/scripts/make_no_merge_user.py
+++ b/scripts/make_no_merge_user.py
@@ -65,7 +65,7 @@ print("making the base branch")
 try:
     subprocess.run(
         "pushd ../cf-test-master && "
-        "git checkout master && "
+        "git checkout main && "
         "git reset --hard HEAD && "
         "git checkout -b %s && "
         "git push --set-upstream origin %s && "

--- a/scripts/make_no_merge_user.py
+++ b/scripts/make_no_merge_user.py
@@ -64,21 +64,19 @@ print("\n\n=========================================")
 print("making the base branch")
 try:
     subprocess.run(
-        "pushd ../cf-test-master && "
-        "git checkout main && "
-        "git reset --hard HEAD && "
-        "git checkout -b %s && "
-        "git push --set-upstream origin %s && "
-        "popd" % (BASE_BRANCH, BASE_BRANCH),
+        f"cd ../cf-test-master && "
+        f"git checkout main && "
+        f"git reset --hard HEAD && "
+        f"git checkout -b {BASE_BRANCH} && "
+        f"git push --set-upstream origin {BASE_BRANCH}",
         shell=True,
         check=True,
     )
 except Exception:
     subprocess.run(
-        "pushd ../cf-test-master && "
-        "git checkout %s && "
-        "git push --set-upstream origin %s && "
-        "popd" % (BASE_BRANCH, BASE_BRANCH),
+        f"cd ../cf-test-master && "
+        f"git checkout {BASE_BRANCH} && "
+        f"git push --set-upstream origin {BASE_BRANCH}",
         shell=True,
     )
 

--- a/scripts/make_prs.py
+++ b/scripts/make_prs.py
@@ -3,8 +3,11 @@ import os
 import sys
 import github
 import subprocess
-import yaml
+from ruamel.yaml import YAML
 import uuid
+
+
+yaml = YAML()
 
 META = """\
 {% set name = "cf-autotick-bot-test-package" %}
@@ -116,7 +119,7 @@ with open("recipe/meta.yaml", "w") as fp:
     fp.write(META)
 
 with open("conda-forge.yml", "r") as fp:
-    cfg = yaml.safe_load(fp)
+    cfg = yaml.load(fp)
 
 cfg["provider"]["linux"] = sys.argv[1]
 cfg["provider"]["osx"] = sys.argv[2]

--- a/scripts/make_prs.py
+++ b/scripts/make_prs.py
@@ -65,7 +65,7 @@ print("making the base branch")
 try:
     subprocess.run(
         "pushd ../cf-test-master && "
-        "git checkout master && "
+        "git checkout main && "
         "git reset --hard HEAD && "
         "git checkout -b %s && "
         "git push --set-upstream origin %s && "

--- a/scripts/make_prs.py
+++ b/scripts/make_prs.py
@@ -64,21 +64,19 @@ print("\n\n=========================================")
 print("making the base branch")
 try:
     subprocess.run(
-        "pushd ../cf-test-master && "
-        "git checkout main && "
-        "git reset --hard HEAD && "
-        "git checkout -b %s && "
-        "git push --set-upstream origin %s && "
-        "popd" % (BASE_BRANCH, BASE_BRANCH),
+        f"cd ../cf-test-master && "
+        f"git checkout main && "
+        f"git reset --hard HEAD && "
+        f"git checkout -b {BASE_BRANCH} && "
+        f"git push --set-upstream origin {BASE_BRANCH}",
         shell=True,
         check=True,
     )
 except Exception:
     subprocess.run(
-        "pushd ../cf-test-master && "
-        "git checkout %s && "
-        "git push --set-upstream origin %s && "
-        "popd" % (BASE_BRANCH, BASE_BRANCH),
+        f"cd ../cf-test-master && "
+        f"git checkout {BASE_BRANCH} && "
+        f"git push --set-upstream origin {BASE_BRANCH}",
         shell=True,
     )
 

--- a/scripts/move_to_dev_branch.py
+++ b/scripts/move_to_dev_branch.py
@@ -30,7 +30,7 @@ subprocess.run(
     "git checkout main && "
     "git pull && "
     "git add .github/workflows/automerge.yml && "
-    "git ci --allow-empty -m '[ci skip] automerge to dev' && "
+    "git commit --allow-empty -m '[ci skip] automerge to dev' && "
     "git push",
     shell=True,
     check=True,

--- a/scripts/move_to_dev_branch.py
+++ b/scripts/move_to_dev_branch.py
@@ -27,7 +27,7 @@ jobs:
 
 subprocess.run(
     "pushd ../cf-test-master && "
-    "git checkout master && "
+    "git checkout main && "
     "git pull && "
     "git add .github/workflows/automerge.yml && "
     "git ci --allow-empty -m '[ci skip] automerge to dev' && "

--- a/scripts/move_to_dev_branch.py
+++ b/scripts/move_to_dev_branch.py
@@ -26,13 +26,12 @@ jobs:
 """)
 
 subprocess.run(
-    "pushd ../cf-test-master && "
+    "cd ../cf-test-master && "
     "git checkout main && "
     "git pull && "
     "git add .github/workflows/automerge.yml && "
     "git ci --allow-empty -m '[ci skip] automerge to dev' && "
-    "git push && "
-    "popd",
+    "git push",
     shell=True,
     check=True,
 )

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -7,8 +7,8 @@ export CONDA_SMITHY_LOGLEVEL=DEBUG
 pushd cf-autotick-bot-test-package-feedstock
 
 git reset --hard HEAD
-git checkout master
-git pull upstream master
+git checkout main
+git pull upstream main
 git pull
 git push
 


### PR DESCRIPTION
- Replace references to `master` with `main`
- Replace PyYAML with ruamel.yaml since that's what's in the environment
- Replace `pushd` with `cd` for shell subprocesses (`pushd` is pointless in a subshell, and `subprocess.run` uses `sh` where `pushd` isn't defined)
- Minor edits to README (Closes #10)

checklist:

- [ ] tested the changes live by using the `dev` version of the action
