### PR TITLE
Fix check pr logic

### DIFF
--- a/conda_forge_automerge_action/automerge.py
+++ b/conda_forge_automerge_action/automerge.py
@@ -316,6 +316,17 @@ def _no_extra_pr_commits(pr):
 
 def _check_pr(pr: PullRequest, cfg):
     """make sure a PR is ok to automerge"""
+    # Ensure files under .github/workflows have not been modified
+    for f in pr.get_files():
+        if f.filename.startswith(".github/workflows"):
+            return False, (
+                "GitHub Actions workflow files have been modified, and thus automerge "
+                "cannot proceed due to API permission limitations. Please merge "
+                "manually."
+            )
+
+    # If the automerge label is present, check that no commits have been added.
+    # If not, then we are good-to-go.
     if any(label.name == "automerge" for label in pr.get_labels()):
         _no_commits = _no_extra_pr_commits(pr)
         if _no_commits is None:
@@ -364,14 +375,6 @@ maintainer to do so) if you'd like to enable automerge again!
     # can we automerge in this feedstock?
     if not _automerge_me(cfg):
         return False, "automated bot merges are turned off for this feedstock"
-
-    # Ensure files under .github/workflows have not been modified
-    if any(f.filename.startswith(".github/workflows") for f in pr.get_files()):
-        return False, (
-            "GitHub Actions workflow files have been modified, and thus automerge "
-            "cannot proceed due to API permission limitations. Please merge "
-            "manually."
-        )
 
     return True, None
 


### PR DESCRIPTION
My check for modified workflow files is not being executed when the PR is marked with the `automerge` label. This is because I added the check at the end of the `_check_pr` function. The flow logic contains two disjoint branches, and so my check only executes in the second branch (the case where there is no automerge label).

My first commit moves the location of the check so that it runs before the branches split.

My second commit is purely style-based refactoring to improve readability. I add `else:` to emphasize that the branches are disjoint. (This is not immediately obvious at a glance, since one must check that the first branch always returns.) In order to verify that all logical branches have a return, I added a type annotation and checked with Pyright.

checklist:

- [ ] tested the changes live by using the `dev` version of the action
