### PR TITLE
Handle GithubException.data is None

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
     language_version: python3
 
 # Enforce coding conventions.
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 4.0.1
   hooks:
   - id: flake8

--- a/conda_forge_automerge_action/automerge.py
+++ b/conda_forge_automerge_action/automerge.py
@@ -474,8 +474,8 @@ def _automerge_pr(repo: Repository, pr: PullRequest) -> tuple[bool, str | None]:
     except GithubException as e:
         merge_status_merged = False
         merge_status_message = "API error in PUT to merge"
-        LOGGER.exception(merge_status_message)
-        if "message" in e.data:
+        LOGGER.exception(merge_status_message + ":")
+        if e.data is not None and "message" in e.data:
             merge_status_message += f" -- '{e.data['message']}'"
     except Exception:
         merge_status_merged = False


### PR DESCRIPTION
In [these automerge logs](https://github.com/conda-forge/poetry-feedstock/actions/runs/3668872274/jobs/6202301423) it happened that there was a `GithubException` on the "merge" API call which failed, and `data` was `None` rather than being the expected dict, presumably since there was an HTTP 500 error.

<details>

<summary> Full log with stack trace </summary>

```
Run conda-forge/automerge-action@main
/usr/bin/docker run --name condaforgeautomergeactionprod_83a22f --label 290506 --workdir /github/workspace --rm -e "INPUT_GITHUB_TOKEN" -e "INPUT_RERENDERING_GITHUB_TOKEN" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" -e "GITHUB_ACTOR" -e "GITHUB_TRIGGERING_ACTOR" -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" -e "GITHUB_STATE" -e "GITHUB_OUTPUT" -e "RUNNER_OS" -e "RUNNER_ARCH" -e "RUNNER_NAME" -e "RUNNER_TOOL_CACHE" -e "RUNNER_TEMP" -e "RUNNER_WORKSPACE" -e "ACTIONS_RUNTIME_URL" -e "ACTIONS_RUNTIME_TOKEN" -e "ACTIONS_CACHE_URL" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/poetry-feedstock/poetry-feedstock":"/github/workspace" condaforge/automerge-action:prod  "***" ""
 
===================================================================================================
===================================================================================================
INFO:conda_forge_automerge_action.__main__:making API clients
INFO:conda_forge_automerge_action.__main__:github event: check_suite
INFO:conda_forge_automerge_action.automerge:status: name|state = conda-forge-linter|True
INFO:conda_forge_automerge_action.automerge:check: name|state = azure-pipelines|True
INFO:conda_forge_automerge_action.automerge:final status: name|state = linter|True
INFO:conda_forge_automerge_action.automerge:final status: name|state = azure|True
ERROR:conda_forge_automerge_action.automerge:API error in PUT to merge
Traceback (most recent call last):
  File "/cf-autotick-bot-action/conda_forge_automerge_action/automerge.py", line 463, in _automerge_pr
    merge_status = pr.merge(
                   ^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/github/PullRequest.py", line 883, in merge
    headers, data = self._requester.requestJsonAndCheck(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/github/Requester.py", line 353, in requestJsonAndCheck
    return self.__check(
           ^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/github/Requester.py", line 378, in __check
    raise self.__createException(status, responseHeaders, output)
github.GithubException.GithubException: 500 null
Traceback (most recent call last):
  File "/cf-autotick-bot-action/conda_forge_automerge_action/automerge.py", line 463, in _automerge_pr
    merge_status = pr.merge(
                   ^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/github/PullRequest.py", line 883, in merge
    headers, data = self._requester.requestJsonAndCheck(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/github/Requester.py", line 353, in requestJsonAndCheck
    return self.__check(
           ^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/github/Requester.py", line 378, in __check
    raise self.__createException(status, responseHeaders, output)
github.GithubException.GithubException: 500 null

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/bin/run-automerge-action", line 33, in <module>
    sys.exit(load_entry_point('conda-forge-automerge-action', 'console_scripts', 'run-automerge-action')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cf-autotick-bot-action/conda_forge_automerge_action/__main__.py", line 37, in main
    automerge_pr(repo, pr)
  File "/cf-autotick-bot-action/conda_forge_automerge_action/automerge.py", line 516, in automerge_pr
    did_merge, reason = _automerge_pr(repo, pr)
                        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/cf-autotick-bot-action/conda_forge_automerge_action/automerge.py", line 478, in _automerge_pr
    if "message" in e.data:
       ^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```

</details>

This adds a check so that instead of crashing when `data` is `None`, the action can still post a message in the PR about its failure.

checklist:

- [ ] tested the changes live by using the `dev` version of the action
