### PR TITLE
Setup cron job, enable CI restart and rebuild for `git` & `setuptools`

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,17 @@
+name: keep-alive
+on:
+  schedule:
+    - cron: "0 6 * * SUN"  # Once weekly on Sunday @ 0600 UTC
+
+jobs:
+  keep-alive:
+    name: Alive
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gautamkrishnar/keepalive-workflow@1b33e4ef553c59eef0e3450666408021f4b0f456
+        with:
+          commit_message: "Ah ah ah, stayin' alive"
+          committer_username: conda-forge-bot
+          committer_email: "conda-forge-bot@users.noreply.github.com"
+          time_elapsed: 50  # days

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           username: condaforgebot
-          password: ${{ secrets.DH_PASSWORD }}
+          password: ${{ secrets.CF_BOT_DH_PASSWORD }}
 
       - name: Build and push
         uses: docker/build-push-action@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request: null
+  workflow_dispatch: null
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,3 +45,24 @@ jobs:
         shell: bash -l {0}
         run: |
           docker build --no-cache -t test .
+
+  docker-push:
+    name: docker-push
+    runs-on: "ubuntu-latest"
+    needs: tests
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: condaforgebot
+          password: ${{ secrets.DH_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: condaforge/automerge-action:prod

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request: null
+  schedule:
+    - cron: "0 6 * * SUN"  # Once weekly on Sunday @ 0600 UTC
   workflow_dispatch: null
 
 jobs:


### PR DESCRIPTION
Sets up a weekly cron job to run on off hours where CI usage should be low. This aligns with other similar changes ( https://github.com/conda-forge/webservices-dispatch-action/pull/21 )

Adds a button on CI to enable kicking off a build of the image manually when needed.

Also `git` [fixed some CVEs recently]( https://github.blog/2023-01-17-git-security-vulnerabilities-announced-2/ ) in `2.39.1` ( https://github.com/conda-forge/git-feedstock/pull/127 ). The new package is in conda-forge, but we need a rebuild of the image to get it.

Finally rebuild to get `conda-build` repodata patch for `setuptools` ( https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/387 ).

<hr>

checklist:

- [ ] tested the changes live by using the `dev` version of the action
