### PR TITLE
Fix keep alive

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,7 +1,7 @@
 name: keep-alive
 on:
   schedule:
-    - cron: "0 6 * * SUN"  # Once weekly on Sunday @ 0600 UTC
+    - cron: "0 6 * * SUN" # Once weekly on Sunday @ 0600 UTC
 
 permissions:
   contents: write
@@ -11,10 +11,11 @@ jobs:
     name: Alive
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.5
-      - uses: gautamkrishnar/keepalive-workflow@beb86212524e1ae856d1cd80efb44e73bf7daf4a  # v2.0.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: gautamkrishnar/keepalive-workflow@beb86212524e1ae856d1cd80efb44e73bf7daf4a # 2.0.1
         with:
           commit_message: "Ah ah ah, stayin' alive"
           committer_username: conda-forge-bot
           committer_email: "conda-forge-bot@users.noreply.github.com"
+          time_elapsed: 50 # days
           use_api: false

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -17,4 +17,4 @@ jobs:
           commit_message: "Ah ah ah, stayin' alive"
           committer_username: conda-forge-bot
           committer_email: "conda-forge-bot@users.noreply.github.com"
-          time_elapsed: 50  # days
+          use_api: false

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -14,4 +14,4 @@ jobs:
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v2
         with:
           python-version: '3.11'
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # 646c83fcd040023954eafda54b4db0192ce70507
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request: null
   schedule:
-    - cron: "0 6 * * SUN"  # Once weekly on Sunday @ 0600 UTC
+    - cron: "0 6 * * SUN" # Once weekly on Sunday @ 0600 UTC
   workflow_dispatch: null
 
 concurrency:
@@ -17,9 +17,9 @@ jobs:
     name: tests
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v4.1.5
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3
         with:
           python-version: "3.11"
           channels: conda-forge,defaults
@@ -46,7 +46,7 @@ jobs:
 
       - name: generate token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1 # v1
         with:
           app-id: ${{ secrets.CF_CURATOR_APP_ID }}
           private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
@@ -71,25 +71,25 @@ jobs:
     needs: tests
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4.1.5
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3
         with:
           username: condaforgebot
           password: ${{ secrets.CF_BOT_DH_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5
         with:
           push: true
           tags: condaforge/automerge-action:prod
 
       - name: Push README to Dockerhub
-        uses: christian-korneck/update-container-description-action@v1
+        uses: christian-korneck/update-container-description-action@d36005551adeaba9698d8d67a296bd16fa91f8e8 # v1
         env:
           DOCKER_USER: condaforgebot
           DOCKER_PASS: ${{ secrets.CF_BOT_DH_PASSWORD }}


### PR DESCRIPTION
The keep alive v2 action allows to use the GH API instead of dummy commits. However, it comes with a few pitfalls 🤔 

- The API call keeps a _workflow_ alive, not the entire repository. So we need to either add the step to every workflow to keep alive, or use the `workflows` setting. This is prone to break.
- We need to update the `permissions` in the workflow too.

For that reason, I'm forcing the use of commit mode (`use_api: false`) that simply keeps everything operational without further work (and it's also future proof in case more cron based workflows are added). I don't think we care too much about the commit history, but let me know otherwise.

I've also re-run the pin-github-actions script to actually pin things here. Somehow it was missed in the previous PRs.