### PR TITLE
add github-actions as a required provider (for self-hosted)

### DIFF
--- a/conda_forge_automerge_action/automerge.py
+++ b/conda_forge_automerge_action/automerge.py
@@ -242,6 +242,9 @@ def _get_required_checks_and_statuses(pr, cfg):
             if os.path.exists("azure-pipelines.yml"):
                 required.append("azure")
 
+            if os.path.exists(".github/workflows/conda-build.yml"):
+                required.append("github-actions")
+
             # smithy writes this config even if circle is off, but we can check
             # for other things
             if os.path.exists(".circleci/config.yml") and _circle_is_active():


### PR DESCRIPTION
I think we were not considering the self-hosted runners here. I checked which slugs [this commit](https://github.com/conda-forge/pytorch-cpu-feedstock/commit/ef00600f06a0c86dff19bdfb3f5ffbb85ce3ddc2) in `pytorch-cpu-feedstock` has with:

```python
>>> repo = gh.get_repo("conda-forge/pytorch-cpu-feedstock")
>>> c = repo.get_commit("ef00600f06a0c86dff19bdfb3f5ffbb85ce3ddc2")
>>> ss = c.get_check_suites()
>>> for s in ss:
...   print(s.app.slug, s.status, s.conclusion)
... 
github-actions completed success
cirun-application completed success
azure-pipelines completed success
```