### PR TITLE
Use miniforge, update pins

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -10,8 +10,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v3
-      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v2
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: '3.11'
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,27 +19,26 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3
+      - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3.0.4
         with:
           python-version: "3.11"
-          channels: conda-forge,defaults
+          channels: conda-forge
           channel-priority: strict
           show-channel-urls: true
           miniforge-version: latest
-          miniforge-variant: Mambaforge
           environment-file: environment.yml
 
       - name: configure conda and install code
-        shell: bash -l {0}
+        shell: bash -el {0}
         run: |
           conda info -a
 
-          mamba install pytest conda-smithy
+          conda install pytest conda-smithy
 
           pip install --no-deps -e .
 
       - name: lint and run tests
-        shell: bash -l {0}
+        shell: bash -el {0}
         run: |
           pytest -vv conda_forge_automerge_action
           command -v run-automerge-action
@@ -53,7 +52,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: run live tests
-        shell: bash -l {0}
+        shell: bash -el {0}
         run: |
           echo "${DH_PASSWORD}" | docker login -u condaforgebot --password-stdin
           git config --global user.name "conda-forge-admin"
@@ -74,16 +73,16 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
         with:
           username: condaforgebot
           password: ${{ secrets.CF_BOT_DH_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@15560696de535e4014efeff63c48f16952e52dd1 # v5
+        uses: docker/build-push-action@15560696de535e4014efeff63c48f16952e52dd1 # v6.2.0
         with:
           push: true
           tags: condaforge/automerge-action:prod


### PR DESCRIPTION
Comes from https://github.com/conda-forge/miniforge/issues/602#issuecomment-2248188930

We were mixing Mambaforge and Miniforge, and they should be equivalent.

Also updated the version comments for some GHA hash pins.